### PR TITLE
feat: implement slide-in animation for navigation sections with z-ind…

### DIFF
--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -109,6 +109,7 @@ body{
     grid-template-columns: auto;
     justify-content: center;
     align-content: space-between;
+    z-index: 5;
 
     .user-picture-wrapper{
       @include mixins.profilePictureWrapper(3.125rem, 3.125rem, hidden);
@@ -188,7 +189,7 @@ body{
         background: none;
         
         &.overlay-active {
-          z-index: 2;
+          z-index: 7;
           position: fixed;
           left: 0;
 
@@ -280,6 +281,16 @@ body{
           }
         }
       }
+
+      section:not(#add-contact-section, #message-section) {
+        transform: translateX(-100%);
+        transition: 0.5s;
+        
+        &.active {
+          transform: translateX(0);
+          z-index: 1;
+        }
+      }
     }
 
     section{
@@ -288,10 +299,6 @@ body{
       width: 100%;
       top: 0;
       left: 0;
-
-      &.active{
-        z-index: 1;
-      }
 
       .title{
         grid-area: title;


### PR DESCRIPTION
## Slide-in Animation for Chat Navigation Sections

Implements a slide-in entry animation for chat navigation sections, with z-index adjustments to ensure proper stacking of elements.

### Changes
- Adds `transform: translateX(-100%)` with `transition: 0.5s` for slide-in animation on navigation sections  
- Sections receive `transform: translateX(0)` when they have the `.active` class  
- z-index adjustment: `body > main` now has `z-index: 5`  
- `.overlay-active` now has `z-index: 7` (was 2)  
- Sections with `.active` inside `body > main > nav` receive `z-index: 1`  
- Removes fixed z-index from `section.active` at the root level  

### Modified File
- `src/sass/app.scss` (12 additions, 5 removals)