### PR TITLE
feat: implement modal to preview sent images in contact conversation.

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -298,6 +298,7 @@ class AppController {
       fn: (e) => {
         this.handleDownloadFile(e)
         this.handleSendMessageFromContact(e)
+        this.handlePictureFromContact(e)
       },
       behavior: {
         preventDefault: true
@@ -394,7 +395,6 @@ class AppController {
 
     if (!granted) return
 
-    console.log('depois do if')
     const userData = JSON.parse(LocalStorage.getUserData())
     const cacheObject = ProfileCache.get()
     const contacts = cacheObject?.cache || []
@@ -1121,6 +1121,13 @@ class AppController {
     }
 
     this.#view.toggleConfirmChatModal(this.#pendingContactData)
+  }
+
+  async handlePictureFromContact(e) {
+    const sentPicture = e.target.closest('.picture')
+    if (!sentPicture) return
+    
+    await this.#view.openPicture(sentPicture)
   }
 
   async handleConfirmSendMessage() {

--- a/src/view/AppView.js
+++ b/src/view/AppView.js
@@ -484,10 +484,11 @@ class AppView extends AbstractView {
   }
 
   clearMediaProperties() {
-    const { uploadFile, sentImagePreview, pdfArea } = this.$()
+    const { uploadFile, sentImagePreview, pdfArea, sentImageName } = this.$()
 
     uploadFile.value = ''
     sentImagePreview.src = ''
+    sentImageName.innerText = ''
 
     const context = pdfArea.getContext('2d')
     context.clearRect(0, 0, pdfArea.width, pdfArea.height)
@@ -764,6 +765,15 @@ class AppView extends AbstractView {
       deleteAccountBtnLabel.style.display = ''
       deleteAccountLoading.classList.add('hidden')
     }
+  }
+
+  async openPicture(sentPicture) {
+    const imgElement = sentPicture.querySelector('.image-area img')
+    const { sentImagePreview, sentImageName  } = this.$()
+    sentImagePreview.src = imgElement.src
+    sentImageName.innerText = ''
+
+    await this.toggleMediaModal('image-preview')
   }
 }
 


### PR DESCRIPTION
## Summary
Added functionality to preview images sent in the chat conversation.

## Changes
- **Image Preview**: When clicking on an image sent in the conversation, a modal opens displaying the image in a larger size.
- **State Cleanup**: Ensures that the image name is correctly cleared when resetting media properties.
- **Refactoring**: Remove residual console.log from the code.